### PR TITLE
Fix DataVariables length for reset_index drop

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -365,7 +365,12 @@ class DataVariables(Mapping[Any, "DataArray"]):
         )
 
     def __len__(self) -> int:
-        return len(self._dataset._variables) - len(self._dataset._coord_names)
+        # some coordinate names may not exist in ``_variables``
+        return sum(
+            1
+            for key in self._dataset._variables
+            if key not in self._dataset._coord_names
+        )
 
     def __contains__(self, key: Hashable) -> bool:
         return key in self._dataset._variables and key not in self._dataset._coord_names
@@ -1395,13 +1400,11 @@ class Dataset(
         return _LocIndexer(self)
 
     @overload
-    def __getitem__(self, key: Hashable) -> DataArray:
-        ...
+    def __getitem__(self, key: Hashable) -> DataArray: ...
 
     # Mapping is Iterable
     @overload
-    def __getitem__(self: T_Dataset, key: Iterable[Hashable]) -> T_Dataset:
-        ...
+    def __getitem__(self: T_Dataset, key: Iterable[Hashable]) -> T_Dataset: ...
 
     def __getitem__(
         self: T_Dataset, key: Mapping[Any, Any] | Hashable | Iterable[Hashable]
@@ -1757,8 +1760,7 @@ class Dataset(
         unlimited_dims: Iterable[Hashable] | None = None,
         compute: bool = True,
         invalid_netcdf: bool = False,
-    ) -> bytes:
-        ...
+    ) -> bytes: ...
 
     # default return None
     @overload
@@ -1773,8 +1775,7 @@ class Dataset(
         unlimited_dims: Iterable[Hashable] | None = None,
         compute: Literal[True] = True,
         invalid_netcdf: bool = False,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     # compute=False returns dask.Delayed
     @overload
@@ -1790,8 +1791,7 @@ class Dataset(
         *,
         compute: Literal[False],
         invalid_netcdf: bool = False,
-    ) -> Delayed:
-        ...
+    ) -> Delayed: ...
 
     def to_netcdf(
         self,
@@ -1916,8 +1916,7 @@ class Dataset(
         region: Mapping[str, slice] | None = None,
         safe_chunks: bool = True,
         storage_options: dict[str, str] | None = None,
-    ) -> ZarrStore:
-        ...
+    ) -> ZarrStore: ...
 
     # compute=False returns dask.Delayed
     @overload
@@ -1936,8 +1935,7 @@ class Dataset(
         region: Mapping[str, slice] | None = None,
         safe_chunks: bool = True,
         storage_options: dict[str, str] | None = None,
-    ) -> Delayed:
-        ...
+    ) -> Delayed: ...
 
     def to_zarr(
         self,
@@ -6498,7 +6496,6 @@ class Dataset(
         fill_value: Any = xrdtypes.NA,
         **shifts_kwargs: int,
     ) -> T_Dataset:
-
         """Shift this dataset by an offset along one or more dimensions.
 
         Only data variables are moved; coordinates stay in place. This is
@@ -7666,10 +7663,9 @@ class Dataset(
         self: T_Dataset,
         pad_width: Mapping[Any, int | tuple[int, int]] = None,
         mode: PadModeOptions = "constant",
-        stat_length: int
-        | tuple[int, int]
-        | Mapping[Any, tuple[int, int]]
-        | None = None,
+        stat_length: (
+            int | tuple[int, int] | Mapping[Any, tuple[int, int]] | None
+        ) = None,
         constant_values: (
             float | tuple[float, float] | Mapping[Any, tuple[float, float]] | None
         ) = None,

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3260,6 +3260,12 @@ class TestDataset:
         assert_identical(obj, ds, check_default_indexes=False)
         assert len(obj.xindexes) == 0
 
+    def test_data_vars_len_after_reset_index_drop(self) -> None:
+        ds = Dataset(coords={"a": ("x", [1, 2, 3]), "b": ("x", ["a", "b", "c"])})
+        result = ds.set_index(z=["a", "b"]).reset_index("z", drop=True)
+        assert len(result.data_vars) == 0
+        assert list(result.data_vars) == []
+
     def test_reorder_levels(self) -> None:
         ds = create_test_multiindex()
         mindex = ds["x"].to_index()


### PR DESCRIPTION
## Summary
- correct DataVariables.__len__ when `coord_names` has entries not present in `_variables`
- add regression test for set_index/reset_index case

## Testing
- `pre-commit run black --files xarray/core/dataset.py xarray/tests/test_dataset.py`
- `pre-commit run blackdoc --files xarray/core/dataset.py xarray/tests/test_dataset.py`
- `pre-commit run flake8 --files xarray/core/dataset.py xarray/tests/test_dataset.py` *(fails: E231 et al. from dataset.py)*
- `pytest xarray/tests/test_dataset.py::TestDataset::test_data_vars_len_after_reset_index_drop -q`

------
https://chatgpt.com/codex/tasks/task_e_68516ac67e84832abc5b13284a27d61f